### PR TITLE
Fix 640px+ Album Cover Background

### DIFF
--- a/DynamicBackground.ts
+++ b/DynamicBackground.ts
@@ -561,7 +561,8 @@ export class DynamicBackground implements Giveable {
         await image.decode();
 
         const originalSize = Math.min(image.width, image.height);
-        const blurExtent = Math.ceil(3 * this.blurAmount);
+        const resizedBlurAmount = this.blurAmount * (originalSize / 640);
+        const blurExtent = Math.ceil(3 * resizedBlurAmount);
 
         const circleCanvas = new OffscreenCanvas(originalSize, originalSize);
         const circleCtx = circleCanvas.getContext('2d')!;
@@ -584,7 +585,7 @@ export class DynamicBackground implements Giveable {
         const blurredCanvas = new OffscreenCanvas(expandedSize, expandedSize);
         const blurredCtx = blurredCanvas.getContext('2d')!;
 
-        blurredCtx.filter = `blur(${this.blurAmount}px) hue-rotate(${placeholderHueShift}deg)`;
+        blurredCtx.filter = `blur(${resizedBlurAmount}px) hue-rotate(${placeholderHueShift}deg)`;
         blurredCtx.drawImage(circleCanvas, (padding / 2), (padding / 2));
 
         this.blurredCoverArts.set(coverArtUrl, blurredCanvas);


### PR DESCRIPTION
`xlarge` Album Covers are always 640x640, but local songs with bigger images have weird backgrounds, the blur amount isn't enough, so just using a ratio with 640 fixes the issue.

Before:
![image](https://github.com/user-attachments/assets/bd1773b1-96a3-42f3-8937-be553881e9e1)
After:
![image](https://github.com/user-attachments/assets/923d5276-46bc-4ec7-b590-254e843250af)
